### PR TITLE
[travis] test allowed_fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ branches:
   only:
     - master
 
+os:
+  - linux
+  - osx
+
+node_js:
+  - node
+  - "7"
+  - "6"
+
 matrix:
   include:
     - os: linux
@@ -21,8 +30,6 @@ matrix:
   allow_failures:
     - os: linux
       node_js: node
-    - os: linux
-      node_js: "7"
     - os: linux
       node_js: "6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,20 @@ branches:
 matrix:
   include:
     - os: linux
-      node_js: node
+      node_js: "7"
       env: COVERALLS=1
-    - os: linux
-      node_js: "7"
-    - os: linux
-      node_js: "6"
     - os: osx
       node_js: node
     - os: osx
       node_js: "7"
     - os: osx
+      node_js: "6"
+  allow_failures:
+    - os: linux
+      node_js: node
+    - os: linux
+      node_js: "7"
+    - os: linux
       node_js: "6"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,9 @@ matrix:
     - os: linux
       node_js: "7"
       env: COVERALLS=1
-    - os: osx
-      node_js: node
-    - os: osx
+  exclude:
+    - os: linux
       node_js: "7"
-    - os: osx
-      node_js: "6"
   allow_failures:
     - os: linux
       node_js: node

--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@
 scuffolut
 =========
 
-This is a testing ground for setting up an es2016/vue project with unit testing via 
+This is a testing ground for setting up an es2016/vue project with custom eslint rules and unit testing via 
 Karma, Mocha, Chai, Istanbul, Travis CI, Appveyor and Coveralls.
 
 When setting up a CI JavaScript project, hopefully the linklist below gives the Questing One
 some pointers into the right direction.
 
 - Note: with the current setup individual builds on Travis with `os: linux` randomly fail with the message 
-"Some of your tests did a full page reload!", but run fine if the exact same build is restarted on Travis... 
-Seems to be a `Karma` problem as far as [this issue](https://github.com/karma-runner/karma/issues/1101) describes it.
+"Some of your tests did a full page reload!", but run fine if the exact same build is restarted on Travis...
+So far it seems, that only builds for Chrome and Opera are affected. Seems to be a `Karma` problem 
+as far as [this issue](https://github.com/karma-runner/karma/issues/1101) describes it.
+Therefore the `.travis.yml` contains allowed fails for `os: linux` builds that test Opera and Chrome.
 
 ### Resources
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,21 +6,15 @@ module.exports = function(config) {
     let cl = {}
     let testBrowsers = ["Opera", "Chromium", "Firefox"]
     if (process.env.TRAVIS && process.env.TRAVIS_OS_NAME === "linux") {
-        testBrowsers = ["PhantomJS", "Chrome", "Firefox", "Opera"]
+        testBrowsers = ["Chrome", "Firefox", "Opera"]
         cl = {
-            Chrome_without_sandbox: {
-                base: "Chrome",
-                flags: ["--no-sandbox"]
-            },
-            Firefox_without_sandbox: {
-                base: "Firefox",
-                flags: ["--no-sandbox"]
-            },
-            Opera_without_sandbox: {
-                base: "Opera",
-                flags: ["--no-sandbox"]
-            }
+            Chrome_without_sandbox: { base: "Chrome", flags: ["--no-sandbox"] },
+            Firefox_without_sandbox: { base: "Firefox", flags: ["--no-sandbox"] },
+            Opera_without_sandbox: { base: "Opera", flags: ["--no-sandbox"] }
         }
+    } else if (process.env.TRAVIS && process.env.TRAVIS_OS_NAME === "linux" && process.env.COVERALLS === 1) {
+        testBrowsers = ["Firefox"]
+        cl = { Firefox_without_sandbox: { base: "Firefox", flags: ["--no-sandbox"] } }
     } else if (process.env.TRAVIS && process.env.TRAVIS_OS_NAME === "osx") {
         testBrowsers = ["Safari", "Firefox", "Chrome"]
     } else if (process.env.APPVEYOR) {
@@ -35,7 +29,6 @@ module.exports = function(config) {
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ["mocha", "browserify"],
-
 
         // list of files / patterns to load in the browser
         files: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,9 +12,10 @@ module.exports = function(config) {
             Firefox_without_sandbox: { base: "Firefox", flags: ["--no-sandbox"] },
             Opera_without_sandbox: { base: "Opera", flags: ["--no-sandbox"] }
         }
-    } else if (process.env.TRAVIS && process.env.TRAVIS_OS_NAME === "linux" && process.env.COVERALLS === 1) {
-        testBrowsers = ["Firefox"]
-        cl = { Firefox_without_sandbox: { base: "Firefox", flags: ["--no-sandbox"] } }
+        if (process.env.COVERALLS === 1) {
+            testBrowsers = ["Firefox"]
+            cl = { Firefox_without_sandbox: { base: "Firefox", flags: ["--no-sandbox"] } }
+        }
     } else if (process.env.TRAVIS && process.env.TRAVIS_OS_NAME === "osx") {
         testBrowsers = ["Safari", "Firefox", "Chrome"]
     } else if (process.env.APPVEYOR) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.13.0",
     "istanbul": "^0.4.5",
-    "karma": "1.5.0",
+    "karma": "^1.6.0",
     "karma-browserify": "^5.0.5",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.0",


### PR DESCRIPTION
With the current setup individual builds on Travis with `os: linux` randomly fail with the message 
"Some of your tests did a full page reload!", but run fine if the exact same build is restarted on Travis...
So far it seems, that only builds for Chrome and Opera are affected. Seems to be a `Karma` problem 
as far as [this issue](https://github.com/karma-runner/karma/issues/1101) describes it.
Therefore the `.travis.yml` contains allowed fails for `os: linux` builds that test Opera and Chrome.